### PR TITLE
toggle contour lock state on autosteerbtn press.

### DIFF
--- a/SourceCode/AOG/Forms/Controls.Designer.cs
+++ b/SourceCode/AOG/Forms/Controls.Designer.cs
@@ -292,6 +292,9 @@ namespace AOG
 
             if (!state && reason != "" && (isBtnAutoSteerOn || triggerstate))
                 TimedMessageBox(2000, gStr.Get(gs.gsGuidanceStopped), reason);
+
+            if (ct.isContourBtnOn)
+                ct.SetLockToLine();
         }
 
         private void btnAutoYouTurn_Click(object sender, EventArgs e)


### PR DESCRIPTION
2 line PR :)
I used contour in the field quite a bit, and got very frustrated with how, after I had engaged autosteer, contour would randomly pick up a different line, and frantically steer after it. This just toggles the lock state so when btnAutoSteerOn is changed, lock will also change.

I realize that this could be a little odd if the user starts clicking it randomly, if someone has some other button logic that makes more sense, feel free to suggest it!