### PR TITLE
Fix for FromISOXML field menu

### DIFF
--- a/SourceCode/AOG/Forms/Field/FormField.cs
+++ b/SourceCode/AOG/Forms/Field/FormField.cs
@@ -234,6 +234,7 @@ namespace AOG
 
         private void btnFromISOXML_Click(object sender, EventArgs e)
         {
+            if (mf.isFieldStarted) mf.FileSaveEverythingBeforeClosingField();
             //back to FormGPS
             DialogResult = DialogResult.Retry;
             Close();


### PR DESCRIPTION
When a field was openend and we ticked From ISOXML, the current field wasnt closed first
