### PR TITLE
fix lateral and manual uturn bugs

### DIFF
--- a/SourceCode/AOG/Forms/GUI.Designer.cs
+++ b/SourceCode/AOG/Forms/GUI.Designer.cs
@@ -984,7 +984,7 @@ namespace AOG
                                 return;
                             }
 
-                            if ( Settings.User.setFeatures.isUTurnOn)
+                            if ( Settings.User.setFeatures.isUTurnOn && isBtnAutoSteerOn)
                             {
                                 //manual uturn triggering
                                 middle = centerX - oglMain.Width / 4;
@@ -1011,7 +1011,7 @@ namespace AOG
                         }
 
                         //lateral
-                        else if (Settings.User.setFeatures.isLateralOn && point.Y < 240 && point.Y > 170)
+                        else if (Settings.User.setFeatures.isLateralOn && isBtnAutoSteerOn && point.Y < 240 && point.Y > 170)
                         {
                             int middle = centerX - oglMain.Width / 4;
                             if (point.X > middle - 100 && point.X < middle + 100)


### PR DESCRIPTION
Lateral and manual uturn button clicks were still being registered, and moving the line over and/or drawing uturn lines even when the icons weren't being shown. This just verifies that isBtnAutoSteerOn is true just like the logic for the icons, so the actions will only be performed when the icons are visible.